### PR TITLE
Use x range for python version. 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup python version
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.x"
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/action.yaml
+++ b/action.yaml
@@ -33,7 +33,7 @@ runs:
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: "3.x"
 
     - name: Install Dependencies
       shell: bash


### PR DESCRIPTION
Pinning it to 3.9 was changing the python version outside of the GHA.