### PR TITLE
Bump python version from 3.9 to 3.x

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup python version
         uses: actions/setup-python@v6
         with:
-          python-version: "3.9"
+          python-version: "3.x"
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/action.yaml
+++ b/action.yaml
@@ -33,7 +33,7 @@ runs:
     - name: Install Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.9"
+        python-version: "3.x"
 
     - name: Install Dependencies
       shell: bash


### PR DESCRIPTION
## Summary
- Switch `actions/setup-python` to `python-version: "3.x"` in `action.yaml` and `.github/workflows/test.yaml` so the latest available Python 3 is used.
- Unblocks dependency bumps such as #23 (requests 2.33.x requires Python >=3.10).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python version requirements to support broader Python 3.x compatibility across build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->